### PR TITLE
Fix indent getting added to list children that weren't other lists

### DIFF
--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -49,4 +49,5 @@ class TestExampleCases:
     def test_example_23(self) -> None: helper("a\n---\nb")
     def test_example_24(self) -> None: assert unmarkd.unmark('''<!DOCTYPE html><html><body><p>A</p></body></html>''') == 'A'
     def test_example_25(self) -> None: helper('>>>')
+    def test_example_26(self) -> None: assert unmarkd.unmark("<ol>\n<li>A</li>\n<li>B</li>\n<li><b>C</b></li></ol>") == "1. A\n2. B\n3. **C**"
 # fmt: on

--- a/unmarkd/unmarkers.py
+++ b/unmarkd/unmarkers.py
@@ -190,9 +190,12 @@ class BaseUnmarker(abc.ABC):
             if str(elstr) == elstr:
                 output += str(elstr).rstrip(" ")
             else:
-                output += textwrap.indent(
-                    self.resolve_handler_func(elstr.name)(elstr), "    "
-                )
+                if elstr.name in ("ol", "ul"):
+                    output += textwrap.indent(
+                        self.resolve_handler_func(elstr.name)(elstr), "    "
+                    )
+                else:
+                    output += self.resolve_handler_func(elstr.name)(elstr)
         return output
 
     def tag_br(self, _: bs4.BeautifulSoup) -> str:


### PR DESCRIPTION
I was running in to an issue where list items using tags where getting indented when they shouldn't of been.

Example:
```
<ol>
    <li>A</li>
    <li>B</li>
    <li><b>C</b></li>
</ol>
```
Output:
```
1. A
2. B
3.     **C**
```

I added a test for this case as well. When doing the roundtrip style test, this indentation got lost, so I made the test compare the markdown output.